### PR TITLE
fix: detect module downgrades in addition to upgrades

### DIFF
--- a/src/compare_nixos_modules.rs
+++ b/src/compare_nixos_modules.rs
@@ -123,7 +123,7 @@ pub fn upgrades_available(new_system_path: &str) -> Result<String, Box<dyn Error
             let new_version = &new_module_version.split('.').collect::<Vec<&str>>();
 
             for (old, new) in old_version.iter().zip(new_version.iter()) {
-                if new > old {
+                if new != old {
                     reason = format!("\n  \x1b[33m⏵\x1b[0m {module} ({old_module_version} -> {new_module_version})");
                     break 'x;
                 }


### PR DESCRIPTION
Previously, the check for module version changes only triggered for upgrades. This meant that a kernel or systemd downgrade would not prompt for a reboot. This change modifies the version comparison logic to check for any inequality between the old and new versions.

This ensures that both upgrades and downgrades of critical modules will correctly indicate that a reboot is required.
